### PR TITLE
Move Sort class methods to non-generic TStrataSort

### DIFF
--- a/StrataSort.pas
+++ b/StrataSort.pas
@@ -10,7 +10,7 @@ unit StrataSort;
 interface
 
 uses
-  SysUtils, Generics.Defaults, Generics.Collections;
+  SysUtils, System.Classes, Generics.Defaults, Generics.Collections;
 
 type
   /// <summary>
@@ -54,6 +54,7 @@ type
       property Eof: Boolean read FEof;    // Eof is only valid after GetFirst or GetNext has been called.
     end;
 
+  private
     /// <summary>
     /// This record type is just used to allow the sort to work with an IComparer<T>.
     /// </summary>
@@ -88,19 +89,22 @@ type
     procedure Sort(const AList: TList<T>); overload;
     procedure Sort(const ASourceList: TList<T>;
                    const ADestinationList: TList<T>); overload;
-    class procedure Sort(const AList: TList<T>;
-                         const ASortCompare: TComparison<T>); overload;
-    class procedure Sort(const AList: TList<T>;
-                         const ASortComparer: IComparer<T>); overload;
-    class procedure Sort(const ASourceList: TList<T>;
-                         const ADestinationList: TList<T>;
-                         const ASortCompare: TComparison<T>); overload;
-    class procedure Sort(const ASourceList: TList<T>;
-                         const ADestinationList: TList<T>;
-                         const ASortComparer: IComparer<T>); overload;
     property Eof: Boolean read GetEof;
   end;
 
+  TStrataSort = class
+  public
+    class procedure Sort<T>(const AList: TList<T>;
+                            const ASortCompare: TComparison<T>); overload;
+    class procedure Sort<T>(const AList: TList<T>;
+                            const ASortComparer: IComparer<T>); overload;
+    class procedure Sort<T>(const ASourceList: TList<T>;
+                            const ADestinationList: TList<T>;
+                            const ASortCompare: TComparison<T>); overload;
+    class procedure Sort<T>(const ASourceList: TList<T>;
+                            const ADestinationList: TList<T>;
+                            const ASortComparer: IComparer<T>); overload;
+  end;
 
 type
   ESortError = class(Exception);
@@ -407,8 +411,11 @@ begin
   inherited;
 end;
 
+
+{ TStrataSort }
+
 // Sort a list into the specified order.
-class procedure TStrataSort<T>.Sort(const AList: TList<T>;
+class procedure TStrataSort.Sort<T>(const AList: TList<T>;
                                     const ASortCompare: TComparison<T>);
 var
   StrataSort: TStrataSort<T>;
@@ -421,13 +428,14 @@ begin
   end;
 end;
 
-class procedure TStrataSort<T>.Sort(const AList: TList<T>;
+class procedure TStrataSort.Sort<T>(const AList: TList<T>;
                                     const ASortComparer: IComparer<T>);
 begin
-  Sort(AList, TComparerInterfaceAdapter.Create(ASortComparer).Compare);
+  Sort<T>(AList,
+          TStrataSort<T>.TComparerInterfaceAdapter.Create(ASortComparer).Compare);
 end;
 
-class procedure TStrataSort<T>.Sort(const ASourceList: TList<T>;
+class procedure TStrataSort.Sort<T>(const ASourceList: TList<T>;
                                     const ADestinationList: TList<T>;
                                     const ASortCompare: TComparison<T>);
 var
@@ -441,12 +449,12 @@ begin
   end;
 end;
 
-class procedure TStrataSort<T>.Sort(const ASourceList: TList<T>;
+class procedure TStrataSort.Sort<T>(const ASourceList: TList<T>;
                                     const ADestinationList: TList<T>;
                                     const ASortComparer: IComparer<T>);
 begin
-  Sort(ASourceList, ADestinationList,
-       TComparerInterfaceAdapter.Create(ASortComparer).Compare);
+  Sort<T>(ASourceList, ADestinationList,
+          TStrataSort<T>.TComparerInterfaceAdapter.Create(ASortComparer).Compare);
 end;
 
 end.

--- a/Test/uSortExampleForm.dfm
+++ b/Test/uSortExampleForm.dfm
@@ -29,6 +29,7 @@ object SortTestForm: TSortTestForm
     ParentFont = False
     ScrollBars = ssVertical
     TabOrder = 1
+    WordWrap = False
   end
   object ButtonPanel: TPanel
     Left = 0

--- a/Test/uSortExampleForm.pas
+++ b/Test/uSortExampleForm.pas
@@ -80,7 +80,7 @@ begin
       if Trim(Str) <> '' then
         StringList.Add(Trim(Str));
     end;
-    TStrataSort<string>.Sort(StringList, ASortCompare);
+    TStrataSort.Sort<string>(StringList, ASortCompare);
     MemoBox.Clear;
     for Str in StringList do
       MemoBox.Lines.Add(Str);

--- a/Test/uSortSpeedTest.dfm
+++ b/Test/uSortSpeedTest.dfm
@@ -29,7 +29,7 @@ object SortSpeedTestForm: TSortSpeedTestForm
     DesignSize = (
       934
       193)
-    object Panel2: TPanel
+    object ListSizePanel: TPanel
       Left = 0
       Top = 0
       Width = 185
@@ -65,13 +65,13 @@ object SortSpeedTestForm: TSortSpeedTestForm
         TabOrder = 0
       end
     end
-    object Panel3: TPanel
-      Left = 185
+    object ItemTypePanel: TPanel
+      Left = 370
       Top = 0
       Width = 185
       Height = 193
       Anchors = [akLeft, akTop, akBottom]
-      TabOrder = 1
+      TabOrder = 2
       object Label2: TLabel
         Left = 12
         Top = 12
@@ -164,13 +164,13 @@ object SortSpeedTestForm: TSortSpeedTestForm
         OnClick = ItemTypeClearButtonClick
       end
     end
-    object Panel4: TPanel
-      Left = 370
+    object ListSequencePanel: TPanel
+      Left = 185
       Top = 0
       Width = 185
       Height = 193
       Anchors = [akLeft, akTop, akBottom]
-      TabOrder = 2
+      TabOrder = 1
       object Label3: TLabel
         Left = 12
         Top = 12
@@ -253,7 +253,7 @@ object SortSpeedTestForm: TSortSpeedTestForm
         OnClick = ListTypeClearButtonClick
       end
     end
-    object Panel5: TPanel
+    object SortTypePanel: TPanel
       Left = 555
       Top = 0
       Width = 185
@@ -312,7 +312,7 @@ object SortSpeedTestForm: TSortSpeedTestForm
         OnClick = SortTypeClearButtonClick
       end
     end
-    object Panel7: TPanel
+    object PlatformPanel: TPanel
       Left = 740
       Top = 0
       Width = 193

--- a/Test/uSortUnitTests.pas
+++ b/Test/uSortUnitTests.pas
@@ -101,8 +101,10 @@ const
 begin
   List := TList<Integer>.Create;
   try
-    TTestAssistant.LoadRandomList<Integer>(TTestAssistant.CreateIntegerTestItem, List, ListSize);
-    TStrataSort<Integer>.Sort(List, TTestAssistant.CompareInteger);
+    TTestAssistant.LoadList<Integer>(TTestAssistant.RandomListValues,
+                                     TTestAssistant.CreateIntegerTestItem,
+                                     List, ListSize);
+    TStrataSort.Sort<Integer>(List, TTestAssistant.CompareInteger);
     TTestAssistant.IntegerSortCheck(List, ListSize, TTestAssistant.CompareInteger, True);
   finally
     List.Free;
@@ -117,8 +119,10 @@ const
 begin
   List := TList<Byte>.Create;
   try
-    TTestAssistant.LoadRandomList<Byte>(TTestAssistant.CreateByteTestItem, List, ListSize);
-    TStrataSort<Byte>.Sort(List, TTestAssistant.CompareByte);
+    TTestAssistant.LoadList<Byte>(TTestAssistant.RandomListValues,
+                                  TTestAssistant.CreateByteTestItem,
+                                  List, ListSize);
+    TStrataSort.Sort<Byte>(List, TTestAssistant.CompareByte);
     TTestAssistant.ByteSortCheck(List, ListSize, TTestAssistant.CompareByte, True);
   finally
     List.Free;
@@ -133,8 +137,10 @@ const
 begin
   List := TList<string>.Create;
   try
-    TTestAssistant.LoadRandomList<string>(TTestAssistant.CreateStringTestItem, List, ListSize);
-    TStrataSort<string>.Sort(List, CompareText);
+    TTestAssistant.LoadList<string>(TTestAssistant.RandomListValues,
+                                    TTestAssistant.CreateStringTestItem,
+                                    List, ListSize);
+    TStrataSort.Sort<string>(List, CompareText);
     TTestAssistant.StringSortCheck(List, ListSize, CompareText, True);
   finally
     List.Free;
@@ -149,8 +155,10 @@ const
 begin
   List := TObjectList<TTestObject>.Create;
   try
-    TTestAssistant.LoadRandomList<TTestObject>(TTestObject.CreateTestItem, List, ListSize);
-    TStrataSort<TTestObject>.Sort(List, TTestObject.Compare);
+    TTestAssistant.LoadList<TTestObject>(TTestAssistant.RandomListValues,
+                                         TTestObject.CreateTestItem,
+                                         List, ListSize);
+    TStrataSort.Sort<TTestObject>(List, TTestObject.Compare);
     TTestObject.SortCheck(List, ListSize, TTestObject.Compare, True);
   finally
     List.Free;
@@ -165,8 +173,10 @@ const
 begin
   List := TList<ITestInterface>.Create;
   try
-    TTestAssistant.LoadRandomList<ITestInterface>(TTestInterfaceObject.CreateTestItem, List, ListSize);
-    TStrataSort<ITestInterface>.Sort(List, TTestInterfaceObject.Compare);
+    TTestAssistant.LoadList<ITestInterface>(TTestAssistant.RandomListValues,
+                                            TTestInterfaceObject.CreateTestItem,
+                                            List, ListSize);
+    TStrataSort.Sort<ITestInterface>(List, TTestInterfaceObject.Compare);
     TTestInterfaceObject.SortCheck(List, ListSize, TTestInterfaceObject.Compare, True);
   finally
     List.Free;
@@ -181,8 +191,10 @@ const
 begin
   List := TList<TTestIntegerRecord>.Create;
   try
-    TTestAssistant.LoadRandomList<TTestIntegerRecord>(TTestIntegerRecord.CreateTestItem, List, ListSize);
-    TStrataSort<TTestIntegerRecord>.Sort(List, TTestIntegerRecord.Compare);
+    TTestAssistant.LoadList<TTestIntegerRecord>(TTestAssistant.RandomListValues,
+                                                TTestIntegerRecord.CreateTestItem,
+                                                List, ListSize);
+    TStrataSort.Sort<TTestIntegerRecord>(List, TTestIntegerRecord.Compare);
     TTestIntegerRecord.SortCheck(List, ListSize, TTestIntegerRecord.Compare, True);
   finally
     List.Free;
@@ -197,8 +209,10 @@ const
 begin
   List := TList<TTestStringRecord>.Create;
   try
-    TTestAssistant.LoadRandomList<TTestStringRecord>(TTestStringRecord.CreateTestItem, List, ListSize);
-    TStrataSort<TTestStringRecord>.Sort(List, TTestStringRecord.Compare);
+    TTestAssistant.LoadList<TTestStringRecord>(TTestAssistant.RandomListValues,
+                                               TTestStringRecord.CreateTestItem,
+                                               List, ListSize);
+    TStrataSort.Sort<TTestStringRecord>(List, TTestStringRecord.Compare);
     TTestStringRecord.SortCheck(List, ListSize, TTestStringRecord.Compare, True);
   finally
     List.Free;
@@ -213,8 +227,10 @@ const
 begin
   List := TList<TTestManagedRecord>.Create;
   try
-    TTestAssistant.LoadRandomList<TTestManagedRecord>(TTestManagedRecord.CreateTestItem, List, ListSize);
-    TStrataSort<TTestManagedRecord>.Sort(List, TTestManagedRecord.Compare);
+    TTestAssistant.LoadList<TTestManagedRecord>(TTestAssistant.RandomListValues,
+                                                TTestManagedRecord.CreateTestItem,
+                                                List, ListSize);
+    TStrataSort.Sort<TTestManagedRecord>(List, TTestManagedRecord.Compare);
     TTestManagedRecord.SortCheck(List, ListSize, TTestManagedRecord.Compare, True);
   finally
     List.Free;
@@ -233,8 +249,10 @@ begin
   try
     DestinationList := TObjectList<TTestObject>.Create(False);
     try
-      TTestAssistant.LoadRandomList<TTestObject>(TTestObject.CreateTestItem, SourceList, ListSize);
-      TStrataSort<TTestObject>.Sort(SourceList, DestinationList, TTestObject.Compare);
+      TTestAssistant.LoadList<TTestObject>(TTestAssistant.RandomListValues,
+                                           TTestObject.CreateTestItem,
+                                           SourceList, ListSize);
+      TStrataSort.Sort<TTestObject>(SourceList, DestinationList, TTestObject.Compare);
       TTestObject.SortCheck(DestinationList, ListSize, TTestObject.Compare, True);
     finally
       DestinationList.Free;
@@ -256,9 +274,11 @@ begin
   try
     DestinationList := TList<ITestInterface>.Create;
     try
-      TTestAssistant.LoadRandomList<ITestInterface>(TTestInterfaceObject.CreateTestItem, SourceList, ListSize);
+      TTestAssistant.LoadList<ITestInterface>(TTestAssistant.RandomListValues,
+                                              TTestInterfaceObject.CreateTestItem,
+                                              SourceList, ListSize);
       SortComparer := TComparer<ITestInterface>.Construct(TTestInterfaceObject.Compare);
-      TStrataSort<ITestInterface>.Sort(SourceList, DestinationList, SortComparer);
+      TStrataSort.Sort<ITestInterface>(SourceList, DestinationList, SortComparer);
       TTestInterfaceObject.SortCheck(DestinationList, ListSize, TTestInterfaceObject.Compare, True);
     finally
       DestinationList.Free;
@@ -305,21 +325,26 @@ var
   Sorter: TStrataSort<TTestObject>;
   List: TObjectList<TTestObject>;
 const
-  ListSize: Integer = 1000;
+  FirstListSize: Integer = 3000;
+  SecondListSize: Integer = 1000;
 begin
   Sorter := TStrataSort<TTestObject>.Create(TTestObject.Compare);
   try
     List := TObjectList<TTestObject>.Create;
     try
-      TTestAssistant.LoadRandomList<TTestObject>(TTestObject.CreateTestItem , List, ListSize);
+      TTestAssistant.LoadList<TTestObject>(TTestAssistant.RandomListValues,
+                                           TTestObject.CreateTestItem,
+                                           List, FirstListSize);
       Sorter.Sort(List);
-      TTestObject.SortCheck(List, ListSize, TTestObject.Compare, True);
+      TTestObject.SortCheck(List, FirstListSize, TTestObject.Compare, True);
 
       List.Clear;
 
-      TTestAssistant.LoadFourValueList<TTestObject>(TTestObject.CreateTestItem , List, ListSize);
+      TTestAssistant.LoadList<TTestObject>(TTestAssistant.FourValueListValues,
+                                           TTestObject.CreateTestItem,
+                                           List, SecondListSize);
       Sorter.Sort(List);
-      TTestObject.SortCheck(List, ListSize, TTestObject.Compare, True);
+      TTestObject.SortCheck(List, SecondListSize, TTestObject.Compare, True);
     finally
       List.Free;
     end;
@@ -342,7 +367,7 @@ begin
       SortList.Add(TSortItem.Create(ValueArray[I], I));
     end;
 
-    TStrataSort<TSortItem>.Sort(SortList, CompareSortItem);
+    TStrataSort.Sort<TSortItem>(SortList, CompareSortItem);
 
     TSortItem.SortCheck(SortList, Count);
   finally


### PR DESCRIPTION
Move Sort class methods to non-generic TStrataSort,
Separate generating list values from loading lists.
Change method names in uSortSpeedTest