### PR TITLE
Add .gitattributes file to reduce line ending issues.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,120 @@
+# .gitattributes should prevent different settings for core.autocrlf changing
+# how source files are stored in the repository.
+
+* text=auto
+
+# Executable files, compressed archives, etc
+*.7z  binary
+*.bat  text
+*.cmd  text
+*.ini  text
+*.txt  text
+*.csv  text
+*.log  text
+*.tar  binary
+*.zip  binary
+*.exe  binary
+*.dll  binary
+
+# Git
+*.gitignore  text
+*.gitattributes  text
+
+# Delphi
+*.dpr  text
+*.dproj  text
+*.dpk  text
+*.groupproj  text
+*.pas  text diff=pascal
+*.inc  text
+*.dcr  binary
+*.dcu  binary
+*.ddp  binary
+*.dfm  text
+*.fmx  text
+*.cfg  text
+*.optset  text
+*.rc  text
+*.res  binary
+*.ridl  text
+*.rsm  binary
+*.stat  text
+*.tds  binary
+*.tlb  binary
+*.bpl  binary
+*.prjmgc text
+
+# Delphi files probably not in version control
+*.drc  text
+*.dres  binary
+*.dsk  text
+*.identcache  binary
+*.local  text
+*.map  text
+*.tvsconfig  text
+
+# Early Delphi
+*.bdsgroup  text
+*.bdsproj  text
+*.dof  text
+*.otares  binary
+
+# Graphics, video, audio
+*.bmp  binary
+*.jpg  binary
+*.png  binary
+*.gif  binary
+*.ico  binary
+*.pbm  binary
+*.pgm  binary
+*.ppm  binary
+*.tif  binary
+*.mp4  binary
+*.wav  binary
+
+# Database
+*.ddl  text
+*.sql  text
+*.fdb  binary
+*.fbk  binary
+*.gdb  binary
+*.gbk  binary
+*.blob  binary
+*.dbf  binary
+
+# Office
+*.doc  binary
+*.docx  binary
+*.ppt  binary
+*.pptx  binary
+*.xls  binary
+*.xlsx  binary
+*.rtf  binary
+*.odg  binary
+*.ods  binary
+*.odt  binary
+*.ott  binary
+*.pdf  binary
+*.ps  text
+
+# Help
+*.chm  binary
+*.cnt  text
+*.hlp  binary
+
+# Web, Xml
+*.htaccess  text
+*.htm  text diff=html
+*.html  text diff=html
+*.css  text diff=css
+*.md  text diff=markdown
+*.dtd  text
+*.xhtml  text
+*.xml  text
+*.xsd  text
+*.xsl  text
+
+# Other
+*.bak  binary
+*.po  text
+


### PR DESCRIPTION
Add .gitattributes file to prevent different core.autocrlf settings changing how source files are stored in the repository.